### PR TITLE
Undefined name: log-fetch-limit --> log_limit

### DIFF
--- a/getwiotpdata.py
+++ b/getwiotpdata.py
@@ -196,7 +196,7 @@ def _getPageOfDevices(client, device_limit, log_limit, bookmark):
                 if log_limit == -1:
                     logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId})
                 else:
-                    logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId, "_limit": log-fetch-limit})
+                    logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId, "_limit": log_limit})
  
 
             logMsgCount = 0  


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/ibm-watson-iot/connector-qradar

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./getwiotpdata.py:199:112: F821 undefined name 'log'
                    logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId, "_limit": log-fetch-limit})
                                                                                                               ^
./getwiotpdata.py:199:116: F821 undefined name 'fetch'
                    logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId, "_limit": log-fetch-limit})
                                                                                                                   ^
./getwiotpdata.py:199:122: F821 undefined name 'limit'
                    logresults = client.api.getConnectionLogs({"typeId":typeId, "deviceId":deviceId, "_limit": log-fetch-limit})
                                                                                                                         ^
3     F821 undefined name 'log'
3
```